### PR TITLE
Add executable success script after submit form

### DIFF
--- a/components/renderform/success.htm
+++ b/components/renderform/success.htm
@@ -5,7 +5,7 @@
 {% if __SELF__.form.success_script %}
     <script>
         window.ocForms = window.ocForms || [];
-        window.ocForms.formData = {{ __SELF__.form | json_encode | raw }};
+        window.ocForms.formData = {{ __SELF__.form.getSafeData | json_encode | raw }};
     </script>
     <script>
         {{ __SELF__.form.success_script | raw }}

--- a/components/renderform/success.htm
+++ b/components/renderform/success.htm
@@ -1,3 +1,13 @@
 <div class="{{ __SELF__.classNames('form-message form-message--success') }}">
     {{ __SELF__.form.success_message }}
 </div>
+
+{% if __SELF__.form.success_script %}
+    <script>
+        window.ocForms = window.ocForms || [];
+        window.ocForms.formData = {{ __SELF__.form | json_encode | raw }};
+    </script>
+    <script>
+        {{ __SELF__.form.success_script | raw }}
+    </script>
+{% endif %}

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -64,6 +64,8 @@ return [
     'rows' => 'Anzahl Zeilen',
     'success_message' => 'Erfolgsmeldung',
     'success_message_comment' => 'Wird dem Absender nach dem Absenden des Formulars angezeigt',
+    'success_script' => 'JavaScript nach dem Absenden',
+    'success_script_comment' => 'Wird nach dem Absenden des Formulars ausgeführt. Formulardaten sind in der Variable `window.ocForms.formData` verfügbar.',
     'validation_email_field_required' => 'Um eine Kopie an den Absender senden zu können, muss ein Feld mit vom Typ E-Mail im Formular vorhanden sein',
     'submit' => 'Absenden',
     'submit_button_label' => 'Text für Absende-Aktion',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -64,6 +64,8 @@ return [
     'rows' => 'Rows',
     'success_message' => 'Success message',
     'success_message_comment' => 'Displayed after the form has been sent successfully',
+    'success_script' => 'Success script',
+    'success_script_comment' => 'Will be executed after the form has been sent successfully. Use the variable `window.ocForms.formData` to access the form data.',
     'validation_email_field_required' => 'To send a copy to the sender, the form must have at least one e-mail fieldTo send a copy to the sender, the form must have at least one e-mail field.',
     'submit' => 'Submit',
     'submit_button_label' => 'Text for submit button',

--- a/models/Form.php
+++ b/models/Form.php
@@ -245,7 +245,6 @@ class Form extends Model
         return [
             'slug' => $this->slug,
             'fields' => collect($this->fields)->keyBy('label')->toArray(),
-            'success_message' => $this->success_message,
         ];
     }
 

--- a/models/Form.php
+++ b/models/Form.php
@@ -238,6 +238,18 @@ class Form extends Model
     }
 
     /**
+     * Safe data returns a safe-for-publication version of the form data.
+     */
+    public function getSafeData(): array
+    {
+        return [
+            'slug' => $this->slug,
+            'fields' => collect($this->fields)->keyBy('label')->toArray(),
+            'success_message' => $this->success_message,
+        ];
+    }
+
+    /**
      * Set the name of each field that has no name set.
      */
     protected function setFieldNames(): void

--- a/models/form/fields.yaml
+++ b/models/form/fields.yaml
@@ -239,11 +239,19 @@ tabs:
             tab: 'offline.forms::lang.config'
         success_message:
             type: textarea
-            size: tiny
+            size: small
             label: 'offline.forms::lang.success_message'
             comment: 'offline.forms::lang.success_message_comment'
             span: left
             tab: 'offline.forms::lang.config'
+        success_script:
+            type: codeeditor
+            language: javascript
+            label: 'offline.forms::lang.success_script'
+            comment: 'offline.forms::lang.success_script_comment'
+            span: right
+            tab: 'offline.forms::lang.config'
+            size: small
         spam_protection_enabled:
             label: 'offline.forms::lang.spam_protection_enabled'
             span: full

--- a/updates/add_success_script_field_to_offline_forms.php
+++ b/updates/add_success_script_field_to_offline_forms.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OFFLINE\FormBuilder\Updates;
+
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class AddSuccessScriptFieldToOfflineForms extends Migration
+{
+    public function up()
+    {
+        Schema::table('offline_forms_forms', function ($table) {
+            $table->text('success_script')->after('send_cc')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('offline_forms_forms', function ($table) {
+            $table->dropColumn('success_script');
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -6,3 +6,6 @@ v1.0.16:
     - Added support for date and time fields.
 v1.0.17:
     - Added duplication action.
+v1.0.18:
+    - 'Added script field that will be executed after submitting the form.'
+    - add_success_script_field_to_offline_forms.php


### PR DESCRIPTION
This pull request allowing the addition of an executable success script after submitting a form. The added code saves the form data in the window variable `window.ocForms.formData` and execute the defined javascript code form the added `success_script field`. This can be used for fire a tracking event after submit the a form:

```javascript
window.dataLayer = window.dataLayer || [];
  window.dataLayer.push({
   'event': 'bookTour',
   'formType': window.ocForms.formData.fields[0].value,
});
```